### PR TITLE
Ability to select showed fields

### DIFF
--- a/src/main/java/com/opsgenie/plugin/graylog/OpsGenieAlarmCallback.java
+++ b/src/main/java/com/opsgenie/plugin/graylog/OpsGenieAlarmCallback.java
@@ -29,6 +29,7 @@ public class OpsGenieAlarmCallback implements AlarmCallback {
     private static final String PRIORITY = "priority";
     private static final String PROXY = "proxy_address";
     private static final String API_URL = "api_url";
+    private static final String SHOW_FIELDS = "show_fields";
 
     private Configuration configuration;
 
@@ -40,7 +41,7 @@ public class OpsGenieAlarmCallback implements AlarmCallback {
     @Override
     public void call(Stream stream, AlertCondition.CheckResult checkResult) throws AlarmCallbackException {
         call(new OpsGenieGraylogClient(configuration.getString(API_KEY), configuration.getString(TAGS),
-                configuration.getString(TEAMS), configuration.getString(PRIORITY), configuration.getString(API_URL), configuration.getString(PROXY)), stream, checkResult);
+                configuration.getString(TEAMS), configuration.getString(PRIORITY), configuration.getString(API_URL), configuration.getString(SHOW_FIELDS), configuration.getString(PROXY)), stream, checkResult);
     }
 
     private void call(OpsGenieGraylogClient opsGenieGraylogClient, Stream stream, AlertCondition.CheckResult checkResult) throws AlarmCallbackException {
@@ -77,6 +78,12 @@ public class OpsGenieAlarmCallback implements AlarmCallback {
                 "OpsGenie API URL", "",
                 "OpsGenie API integration URL",
                 ConfigurationField.Optional.NOT_OPTIONAL));
+
+        configurationRequest.addField(new TextField(SHOW_FIELDS,
+                "Show fields", "",
+                "Comma separated list of displayed fields, default show all",
+                ConfigurationField.Optional.OPTIONAL));
+
 
         HashMap<String, String> priorities = new HashMap<>();
         priorities.put("P1", "P1-Critical");

--- a/src/main/java/com/opsgenie/plugin/graylog/OpsGenieGraylogClient.java
+++ b/src/main/java/com/opsgenie/plugin/graylog/OpsGenieGraylogClient.java
@@ -28,14 +28,16 @@ class OpsGenieGraylogClient {
     private ObjectMapper objectMapper;
     private String apiUrl;
     private final String proxyURL;
+    private String showFields;
 
-    OpsGenieGraylogClient(String apiKey, String tags, String teams, String priority, String apiUrl, String proxyURL) {
+    OpsGenieGraylogClient(String apiKey, String tags, String teams, String priority, String apiUrl, String showFields, String proxyURL) {
         this.apiKey = apiKey;
         this.tags = tags;
         this.teams = teams;
         this.priority = priority;
         this.apiUrl = apiUrl;
         this.proxyURL = proxyURL;
+        this.showFields = showFields;
 
         this.objectMapper = new ObjectMapper();
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -129,14 +131,25 @@ class OpsGenieGraylogClient {
         if (checkResult.getMatchingMessages().size() > 0) {
             stringBuilder.append("\nMatching messages: \n");
             for (MessageSummary summary : checkResult.getMatchingMessages()) {
-
                 stringBuilder.append("Message: ").append(summary.getMessage()).append("\n")
                         .append("Source: ").append(summary.getSource()).append("\n")
                         .append("Stream Ids: ").append(summary.getStreamIds()).append("\n")
-                        .append("Fields: ").append(summary.getFields()).append("\n\n")
-                        .append("------------------").append("\n")
+                        .append("Fields: \n")
                 ;
-
+                if(showFields != null && !showFields.trim().isEmpty()){
+                    summary.getFields().keySet()
+                        .iterator()
+                        .forEachRemaining(
+                            fieldKey -> {
+                                if(Arrays.asList(showFields.split(",")).contains(fieldKey)){
+                                    stringBuilder.append(fieldKey + " = " + summary.getFields().get(fieldKey)).append("\n");
+                                }
+                            }
+                    );
+                }else{
+                    stringBuilder.append(summary.getFields());
+                }
+                stringBuilder.append("\n\n").append("------------------").append("\n");
             }
         }
         request.setDescription(stringBuilder.toString().trim());


### PR DESCRIPTION
Outputting all fields can be quite confusing. So I created a new field that takes comma separated field names that are output. If the field remains empty, all fields are displayed by default.

![new_field](https://user-images.githubusercontent.com/38535321/81544368-b711a680-9377-11ea-952f-046f69c626ea.png)

Before:
```
BANANARANA
Stream : Syslog messages
Trigger Condition: *

Matching messages:
Message: *
Source: *
Stream Ids: [*, 000000000000000000000001]
Fields:
{filebeat_log_offset=1791417, filebeat_logging_date=May 6 14:40:00, gl2_remote_ip=*, gl2_remote_port=33924, filebeat_agent_hostname=*, beats_type=filebeat, gl2_source_input=*, filebeat_@metadata_beat=filebeat, filebeat_@timestamp=2020-05-11T08:24:21.484Z, filebeat_agent_type=filebeat, filebeat_@metadata_version=7.6.2, filebeat_host_name=*, gl2_source_node=* filebeat_agent_version=7.6.2, filebeat_agent_ephemeral_id=*, gl2_accounted_message_size=810, filebeat_input_type=log, filebeat_hostname=*, gl2_message_id=*, filebeat_tags=[syslog], timestamp_2=2020-05-06T14:40:00.000Z, filebeat_ecs_version=1.4.0, filebeat_@metadata_type=_doc, filebeat_source=*, filebeat_app=affenbrot, filebeat_agent_id=*, filebeat_log_file_path=/var/log/syslog}
```

After:
```
 *
Stream : Syslog messages
Trigger Condition: *

Matching messages:
Message: This is an error blaubeere
Source: *
Stream Ids: [*, 000000000000000000000001]
Fields:
filebeat_hostname = *
filebeat_tags = [syslog]
filebeat_ecs_version = 1.4.0
filebeat_app = affenbrot

```